### PR TITLE
Fix callback example

### DIFF
--- a/examples/callback/callback.c
+++ b/examples/callback/callback.c
@@ -156,6 +156,7 @@ static rt_return_value_t cb_alloc(nn_network_t *net, void *function_context) {
 
   func->func.exec_func = cb_exec;
   func->func.free_local_context_func = cb_free;
+  func->func.local_context = 0;
   return RT_RET_FUNCTION_MATCH;
 }
 


### PR DESCRIPTION
Set local_context to 0 to avoid rt_free_context calling free
on unitialized memory when running systems that do not zero
out heap memory.