### PR TITLE
Check api_level of NNabla.

### DIFF
--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -124,6 +124,14 @@ bwd-nnabla-c-runtime-update-function-info: nnabla-c-runtime-docker_image_test
 		$(NNABLA_C_RUNTIME_DOCKER_IMAGE_TEST) make nnabla-c-runtime-update-function-info
 
 ########################################################################################################################
+# Check api_level of NNabla
+.PHONY: bwd-check-api_level
+bwd-check-api_level: nnabla-c-runtime-docker_image_build
+	cd $(NNABLA_C_RUNTIME_DIRECTORY) \
+	&& docker run $(NNABLA_C_RUNTIME_DOCKER_RUN_OPTS) \
+		$(NNABLA_C_RUNTIME_DOCKER_IMAGE_TEST) make check-api_level
+
+########################################################################################################################
 # Tests
 .PHONY: bwd-nnabla-c-runtime-generate-function-test
 bwd-nnabla-c-runtime-generate-function-test: nnabla-c-runtime-docker_image_test

--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -76,6 +76,10 @@ nnabla-c-runtime-update-function-info: nnabla-install
 	@sed -i -e "s/\(NNABLA_VERSION: \).*/\1$(NNABLA_VERSION)/" $(NNABLA_C_RUNTIME_DIRECTORY)/VERSION.txt
 	@sed -i -e "s/API_LEVEL:.*/$(API_LEVEL)/" $(NNABLA_C_RUNTIME_DIRECTORY)/VERSION.txt
 
+.PHONY: check-api_level
+check-api_level: nnabla-c-runtime-build nnabla-install
+	@bash ./build-tools/test/scripts/check_api_level.sh $(NNABLA_C_RUNTIME_DIRECTORY)
+
 .PHONY: nnabla-c-runtime-generate-function-test
 nnabla-c-runtime-generate-function-test: nnabla-install
 	@mkdir -p $(NNABLA_C_RUNTIME_TEST_DIRECTORY)/nnabla

--- a/build-tools/test/scripts/check_api_level.sh
+++ b/build-tools/test/scripts/check_api_level.sh
@@ -1,0 +1,17 @@
+check_api_level_error=0
+NNabla_api_level=`nnabla_cli function_info --api -1 | awk -F 'API_LEVEL: ' '{print $2}'`
+Runtime_api_level=""
+
+for line in $($1/build/src/nnablart/nnablart version);
+do
+  if [[ $line =~ "API_LEVEL" ]]
+  then
+    Runtime_api_level=`echo $line | awk -F "_" '{print $3}' | sed "s/]//g"`
+  fi
+done
+
+if [ "$NNabla_api_level" -ne "$Runtime_api_level" ];then
+  echo "The api_level version of NNabla and NNabla-c-runtime are not synchronized." >&2
+  check_api_level_error=1
+fi
+exit $check_api_level_error

--- a/src/nnablart/dump.c
+++ b/src/nnablart/dump.c
@@ -26,6 +26,7 @@ int dump(nn_network_t *net, int argc, char *argv[]) {
   unsigned int i, j;
 
   printf("NNB: Version: [%d]\n", net->version);
+  printf("NNB: api_level: [%d]\n", net->api_level);
   printf("NNB: Has %d buffers.\n", net->buffers.size);
   int *list = (int *)NN_GET(net, net->buffers.list);
   for (i = 0; i < net->buffers.size; i++) {


### PR DESCRIPTION
This commit provide the following feature:
    - Add build target to check if API_LEVEL synchronized with nnabla_cli
    - A bash script is appended to compare the output of `nnablart version` and `function_info --api -1`.
    - Latest NNabla is installed in a docker to provide necessary running environment
