### PR TITLE
format exec function name.

### DIFF
--- a/src/functions/implements/neural_network/convolution/binary_connect_convolution.c
+++ b/src/functions/implements/neural_network/convolution/binary_connect_convolution.c
@@ -55,7 +55,7 @@ free_binary_connect_convolution_local_context(rt_function_t *f) {
 
 #ifdef CONFIG_BINARYCONNECTCONVOLUTION_FLOAT32
 rt_function_error_t exec_binary_connect_convolution(rt_function_t *f) {
-  return exec_convolution_float(f);
+  return exec_convolution(f);
 }
 #endif /* CONFIG_BINARYCONNECTCONVOLUTION_FLOAT32 */
 

--- a/src/functions/implements/neural_network/convolution/binary_weight_convolution.c
+++ b/src/functions/implements/neural_network/convolution/binary_weight_convolution.c
@@ -55,7 +55,7 @@ free_binary_weight_convolution_local_context(rt_function_t *f) {
 
 #ifdef CONFIG_BINARYWEIGHTCONVOLUTION_FLOAT32
 rt_function_error_t exec_binary_weight_convolution(rt_function_t *f) {
-  return exec_convolution_float(f);
+  return exec_convolution(f);
 }
 #endif /* CONFIG_BINARYWEIGHTCONVOLUTION_FLOAT32 */
 

--- a/src/functions/implements/neural_network/convolution/convolution.c
+++ b/src/functions/implements/neural_network/convolution/convolution.c
@@ -33,7 +33,7 @@
 // Convolution
 rt_function_error_t allocate_convolution_local_context(rt_function_t *f) {
 #ifdef CONFIG_CONVOLUTION_FLOAT32
-  f->exec_func = exec_convolution_float;
+  f->exec_func = exec_convolution;
 #endif /* CONFIG_CONVOLUTION_FLOAT32 */
 
 #ifdef CONFIG_CONVOLUTION_GENERIC
@@ -82,8 +82,8 @@ rt_function_error_t allocate_convolution_local_context(rt_function_t *f) {
 
 #ifdef CONFIG_CONVOLUTION_FLOAT32
     if ((f->outputs[i]->type == NN_DATA_TYPE_FLOAT) &&
-        (f->exec_func == exec_convolution_float)) {
-      f->exec_func = exec_convolution_float;
+        (f->exec_func == exec_convolution)) {
+      f->exec_func = exec_convolution;
       conv_output_assigned = 1;
       break;
     }

--- a/src/functions/implements/neural_network/convolution/convolution_float.c
+++ b/src/functions/implements/neural_network/convolution/convolution_float.c
@@ -139,7 +139,7 @@ static inline void mul_alpha(var_t *out, var_t *a) {
   }
 }
 
-rt_function_error_t exec_convolution_float(rt_function_t *f) {
+rt_function_error_t exec_convolution(rt_function_t *f) {
   convolution_local_context_t *c =
       (convolution_local_context_t *)f->local_context;
   convolution_private_t *p = (convolution_private_t *)(c->data);

--- a/src/functions/implements/neural_network/convolution/convolution_internal.h
+++ b/src/functions/implements/neural_network/convolution/convolution_internal.h
@@ -59,7 +59,7 @@ typedef struct {
 #define SPW (1) // width of stride/pad
 
 rt_function_error_t exec_convolution_generic(rt_function_t *f);
-rt_function_error_t exec_convolution_float(rt_function_t *f);
+rt_function_error_t exec_convolution(rt_function_t *f);
 rt_function_error_t exec_convolution_int8(rt_function_t *f);
 rt_function_error_t exec_convolution_int16(rt_function_t *f);
 rt_function_error_t

--- a/src/functions/implements/neural_network/convolution/depthwise_convolution.c
+++ b/src/functions/implements/neural_network/convolution/depthwise_convolution.c
@@ -176,8 +176,8 @@ allocate_depthwise_convolution_local_context(rt_function_t *f) {
 
 #ifdef CONFIG_DEPTHWISECONVOLUTION_FLOAT32
     if ((f->outputs[i]->type == NN_DATA_TYPE_FLOAT) &&
-        (f->exec_func == exec_convolution_float)) {
-      f->exec_func = exec_convolution_float;
+        (f->exec_func == exec_convolution)) {
+      f->exec_func = exec_convolution;
       conv_output_assigned = 1;
       break;
     }
@@ -221,7 +221,7 @@ rt_function_error_t free_depthwise_convolution_local_context(rt_function_t *f) {
 
 #ifdef CONFIG_DEPTHWISECONVOLUTION_FLOAT32
 rt_function_error_t exec_depthwise_convolution(rt_function_t *f) {
-  return exec_convolution_float(f);
+  return exec_convolution(f);
 }
 #endif /* CONFIG_DEPTHWISECONVOLUTION_FLOAT32 */
 


### PR DESCRIPTION
Fix failed to build CSRC by format the exec function name.