### PR TITLE
Fix build without http_proxy

### DIFF
--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -62,10 +62,14 @@ NNABLA_C_RUNTIME_DOCKER_BUILD_ARGS += --build-arg YUM_OPTS='${YUM_OPTS}'
 NNABLA_C_RUNTIME_DOCKER_BUILD_ARGS += --build-arg APT_OPTS='${APT_OPTS}'
 
 # For --add-host while docker build/run
-ADD_HOST=$(shell echo ${http_proxy} | cut -d ':' -f2 | cut -d '/' -f3)
+ifneq  ("${http_proxy}","")
+
+ADD_HOST=$(shell echo $(subst http://,,${http_proxy}) | cut -d ':' -f1)
 ADD_HOST_IP=$(shell getent ahostsv4 ${ADD_HOST} | grep RAW | cut -d ' ' -f1)
 NNABLA_C_RUNTIME_DOCKER_BUILD_ARGS += --add-host '${ADD_HOST}:${ADD_HOST_IP}'
 NNABLA_C_RUNTIME_DOCKER_RUN_OPTS += --add-host '${ADD_HOST}:${ADD_HOST_IP}'
+
+endif
 
 # For download utils options
 NNABLA_C_RUNTIME_DOCKER_BUILD_ARGS += --build-arg CURL_OPTS='${CURL_OPTS}'


### PR DESCRIPTION
Fix makefiles to allow build without http_proxy environment variable setting.
Together with https://github.com/sony/nnabla/pull/922